### PR TITLE
fix(api): fixes for tesla 20.49 API changes

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -112,10 +112,10 @@
               "type": "time"
             }
           ],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('Australia/Adelaide')",
+          "query": "SELECT \"mean_load_instant_power\" FROM \"exec\" WHERE $timeFilter tz('America/New_York')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -134,7 +134,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         },
         {
           "alias": "Solar Energy",
@@ -148,7 +148,7 @@
             }
           ],
           "hide": false,
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "autogen",
           "refId": "B",
@@ -168,7 +168,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         },
         {
           "alias": "Powerwall",
@@ -182,10 +182,10 @@
             }
           ],
           "hide": false,
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(from_pw) - mean(to_pw) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('Australia/Adelaide')",
+          "query": "SELECT mean(from_pw) - mean(to_pw) FROM autogen.exec WHERE $timeFilter GROUP BY time(5m) tz('America/New_York')",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -204,7 +204,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         },
         {
           "alias": "Grid Usage",
@@ -224,10 +224,10 @@
             }
           ],
           "hide": false,
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT mean(from_grid) - mean(to_grid) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('Australia/Adelaide')",
+          "query": "SELECT mean(from_grid) - mean(to_grid) FROM autogen.exec WHERE $timeFilter GROUP BY time(5m) tz('America/New_York')",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series",
@@ -246,7 +246,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         },
         {
           "alias": "Charge",
@@ -266,10 +266,10 @@
             }
           ],
           "hide": false,
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_percentage\" FROM \"http\" WHERE $timeFilter",
+          "query": "SELECT \"mean_percentage\" FROM \"exec\" WHERE $timeFilter",
           "rawQuery": false,
           "refId": "E",
           "resultFormat": "time_series",
@@ -294,7 +294,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         },
         {
           "datasource": "Sun and Moon",
@@ -396,10 +396,10 @@
       "targets": [
         {
           "groupBy": [],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT last(\"percentage\")  /0.95 - 5/0.95 FROM \"http\" WHERE $timeFilter tz('Australia/Adelaide')",
+          "query": "SELECT last(\"percentage\")  /0.95 - 5/0.95 FROM \"exec\" WHERE $timeFilter tz('America/New_York')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -424,7 +424,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         }
       ],
       "timeFrom": null,
@@ -498,10 +498,10 @@
               "type": "fill"
             }
           ],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('Australia/Adelaide'))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.exec WHERE  $timeFilter tz('America/New_York'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -520,12 +520,12 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         },
         {
           "alias": "From Powerwall",
           "groupBy": [],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "autogen",
           "refId": "B",
@@ -551,12 +551,12 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         },
         {
           "alias": "From Grid",
           "groupBy": [],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "autogen",
           "refId": "C",
@@ -582,7 +582,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         }
       ],
       "timeFrom": null,
@@ -653,10 +653,10 @@
           "alias": "solar",
           "groupBy": [],
           "hide": false,
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "kwh",
-          "query": "SELECT sum(\"solar\")   * 0.179 FROM \"daily\".\"http\" WHERE $timeFilter GROUP BY time(1d) tz('Australia/Adelaide')",
+          "query": "SELECT sum(\"solar\")   * 0.179 FROM \"daily\".\"exec\" WHERE $timeFilter GROUP BY time(1d) tz('America/New_York')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -681,7 +681,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         },
         {
           "alias": "combined",
@@ -700,10 +700,10 @@
             }
           ],
           "hide": false,
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT s + g FROM (SELECT sum(solar)  * 0.358 AS s, sum(to_grid) * 0.179 AS g FROM kwh.http WHERE  $timeFilter tz('Australia/Adelaide'))",
+          "query": "SELECT s + g FROM (SELECT sum(solar)  * 0.358 AS s, sum(to_grid) * 0.179 AS g FROM kwh.exec WHERE  $timeFilter tz('America/New_York'))",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series",
@@ -733,10 +733,10 @@
           "alias": "battery",
           "groupBy": [],
           "hide": false,
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "kwh",
-          "query": "SELECT \"from_pw\"   * 0.358 FROM \"kwh\".\"http\" WHERE $timeFilter tz('Australia/Adelaide')",
+          "query": "SELECT \"from_pw\"   * 0.358 FROM \"kwh\".\"exec\" WHERE $timeFilter tz('America/New_York')",
           "rawQuery": false,
           "refId": "C",
           "resultFormat": "time_series",
@@ -757,7 +757,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         }
       ],
       "thresholds": [],
@@ -887,7 +887,7 @@
           "null_color": "darkred",
           "null_textcolor": "black",
           "null_value": "No data",
-          "pattern": "http.Grid",
+          "pattern": "exec.Grid",
           "row_col_wrapper": "_",
           "row_name": "_1_",
           "textColors": "white | white | white",
@@ -926,7 +926,7 @@
           "null_color": "darkred",
           "null_textcolor": "black",
           "null_value": "No data",
-          "pattern": "http.Battery",
+          "pattern": "exec.Battery",
           "row_col_wrapper": "_",
           "row_name": "_1_",
           "textColors": "white | white | white",
@@ -965,7 +965,7 @@
           "null_color": "darkred",
           "null_textcolor": "black",
           "null_value": "No data",
-          "pattern": "http.Solar",
+          "pattern": "exec.Solar",
           "row_col_wrapper": "_",
           "row_name": "_1_",
           "textColors": "white|black",
@@ -986,10 +986,10 @@
       "targets": [
         {
           "groupBy": [],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "raw",
-          "query": "SELECT last(\"battery_instant_power\")  / 1000 AS \"Powerwall\", last(\"solar_instant_power\")  / 1000 AS \"Solar\", last(\"load_instant_power\")  / 1000 AS \"Home\", last(\"site_instant_power\")  / 1000 AS \"Grid\" FROM \"raw\".\"http\" WHERE $timeFilter",
+          "query": "SELECT last(\"battery_instant_power\")  / 1000 AS \"Powerwall\", last(\"solar_instant_power\")  / 1000 AS \"Solar\", last(\"load_instant_power\")  / 1000 AS \"Home\", last(\"site_instant_power\")  / 1000 AS \"Grid\" FROM \"raw\".\"exec\" WHERE $timeFilter",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1166,10 +1166,10 @@
       "targets": [
         {
           "groupBy": [],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT integral(\"load_instant_power\")  / 1000 / 3600 FROM \"http\" WHERE $timeFilter GROUP BY time(1h) tz('Australia/Adelaide')",
+          "query": "SELECT integral(\"load_instant_power\")  / 1000 / 3600 FROM \"exec\" WHERE $timeFilter GROUP BY time(1h) tz('America/New_York')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1194,7 +1194,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         }
       ],
       "thresholds": "",
@@ -1279,10 +1279,10 @@
       "targets": [
         {
           "groupBy": [],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT integral(\"battery_instant_power\")  / 1000 / 3600 FROM \"http\" WHERE (\"battery_instant_power\" > 0) AND $timeFilter tz('Australia/Adelaide')",
+          "query": "SELECT integral(\"battery_instant_power\")  / 1000 / 3600 FROM \"exec\" WHERE (\"battery_instant_power\" > 0) AND $timeFilter tz('America/New_York')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1307,7 +1307,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         }
       ],
       "thresholds": "",
@@ -1392,10 +1392,10 @@
       "targets": [
         {
           "groupBy": [],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT integral(\"site_instant_power\", 1m)  / 1000 / 3600 * 60 FROM \"http\" WHERE (\"site_instant_power\" > 0) AND $timeFilter",
+          "query": "SELECT integral(\"site_instant_power\", 1m)  / 1000 / 3600 * 60 FROM \"exec\" WHERE (\"site_instant_power\" > 0) AND $timeFilter",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1420,7 +1420,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         }
       ],
       "thresholds": "",
@@ -1506,10 +1506,10 @@
         {
           "groupBy": [],
           "limit": "",
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT integral(\"solar_instant_power\")  / 1000 / 3600 FROM \"http\" WHERE $timeFilter",
+          "query": "SELECT integral(\"solar_instant_power\")  / 1000 / 3600 FROM \"exec\" WHERE $timeFilter",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1534,7 +1534,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         }
       ],
       "thresholds": "",
@@ -1621,10 +1621,10 @@
       "targets": [
         {
           "groupBy": [],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT integral(\"battery_instant_power\")  / -1000 / 3600 FROM \"http\" WHERE (\"battery_instant_power\" <= 0) AND $timeFilter GROUP BY time(1h) tz('Australia/Adelaide')",
+          "query": "SELECT integral(\"battery_instant_power\")  / -1000 / 3600 FROM \"exec\" WHERE (\"battery_instant_power\" <= 0) AND $timeFilter GROUP BY time(1h) tz('America/New_York')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1649,7 +1649,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         }
       ],
       "thresholds": "",
@@ -1734,10 +1734,10 @@
       "targets": [
         {
           "groupBy": [],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT integral(\"site_instant_power\",1m)  / -1000 / 3600 * 60 FROM \"http\" WHERE (\"site_instant_power\" < 0) AND $timeFilter GROUP BY time(1h) tz('Australia/Adelaide')",
+          "query": "SELECT integral(\"site_instant_power\",1m)  / -1000 / 3600 * 60 FROM \"exec\" WHERE (\"site_instant_power\" < 0) AND $timeFilter GROUP BY time(1h) tz('America/New_York')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1762,7 +1762,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         }
       ],
       "thresholds": "",
@@ -1853,10 +1853,10 @@
               "type": "fill"
             }
           ],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "kwh",
-          "query": "SELECT sum(\"home\") FROM \"kwh\".\"http\" WHERE $timeFilter GROUP BY time(1d) fill(0) tz('Australia/Adelaide')",
+          "query": "SELECT sum(\"home\") FROM \"kwh\".\"exec\" WHERE $timeFilter GROUP BY time(1d) fill(0) tz('America/New_York')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1875,7 +1875,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         }
       ],
       "thresholds": [],
@@ -1978,7 +1978,7 @@
               "type": "fill"
             }
           ],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "kwh",
           "refId": "A",
@@ -2004,7 +2004,7 @@
               "value": "0"
             }
           ],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         }
       ],
       "thresholds": [],
@@ -2107,7 +2107,7 @@
               "type": "fill"
             }
           ],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "kwh",
           "refId": "A",
@@ -2127,7 +2127,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         }
       ],
       "thresholds": [],
@@ -2176,8 +2176,8 @@
       "aliasColors": {
         "From Grid": "red",
         "To Grid": "purple",
-        "http.From Grid": "red",
-        "http.To Grid": "purple"
+        "exec.From Grid": "red",
+        "exec.To Grid": "purple"
       },
       "bars": true,
       "dashLength": 10,
@@ -2214,7 +2214,7 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "http.From Grid"
+          "alias": "exec.From Grid"
         }
       ],
       "spaceLength": 10,
@@ -2237,10 +2237,10 @@
               "type": "fill"
             }
           ],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "kwh",
-          "query": "SELECT sum(\"from_grid\") FROM \"daily\".\"http\" WHERE $timeFilter GROUP BY time(1d) fill(0) tz('Australia/Adelaide')",
+          "query": "SELECT sum(\"from_grid\") FROM \"daily\".\"exec\" WHERE $timeFilter GROUP BY time(1d) fill(0) tz('America/New_York')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -2259,7 +2259,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         },
         {
           "alias": "To Grid",
@@ -2277,10 +2277,10 @@
               "type": "fill"
             }
           ],
-          "measurement": "http",
+          "measurement": "exec",
           "orderByTime": "ASC",
           "policy": "kwh",
-          "query": "SELECT sum(\"to_grid\")  * -1 FROM \"daily\".\"http\" WHERE $timeFilter GROUP BY time(1d) fill(0) tz('Australia/Adelaide')",
+          "query": "SELECT sum(\"to_grid\")  * -1 FROM \"daily\".\"exec\" WHERE $timeFilter GROUP BY time(1d) fill(0) tz('America/New_York')",
           "rawQuery": false,
           "refId": "B",
           "resultFormat": "time_series",
@@ -2305,7 +2305,7 @@
             ]
           ],
           "tags": [],
-          "tz": "Australia/Adelaide"
+          "tz": "America/New_York"
         }
       ],
       "thresholds": [],

--- a/powerwall.yml
+++ b/powerwall.yml
@@ -20,7 +20,8 @@ services:
               mode: host
 
     telegraf:
-        image: telegraf:1.12
+        image: telegraf
+        build: telegraf
         container_name: telegraf
         hostname: telegraf
         restart: always
@@ -33,6 +34,8 @@ services:
             - "powerwall: 192.168.91.1"
         depends_on:
             - influxdb
+        env_file:
+            - .env.telegraf
 
     grafana:
         image: grafana/grafana:6.5.1-ubuntu

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,11 @@ Monitoring the Tesla Powerwall with the TICK framework
 
 ## Installation
 * edit `powerwall.yml` and replace `192.168.91.1` with your powerwall IP
+* create a file called `.env.telegraf` to define the `POWERWALL_PASSWORD` which
+  is used for authentication. This should be a single line that looks like this:
+	```
+	POWERWALL_PASSWORD=YourPowerwallPassword
+	```
 * start the docker containers: `docker-compose -f powerwall.yml up -d`
 * connect to the Influx database shell: `docker exec -it influxdb influx`
 * at the database prompt, enter the following commands:
@@ -19,10 +24,10 @@ Monitoring the Tesla Powerwall with the TICK framework
 	CREATE RETENTION POLICY kwh ON powerwall duration INF replication 1
 	CREATE RETENTION POLICY daily ON powerwall duration INF replication 1
 	CREATE RETENTION POLICY monthly ON powerwall duration INF replication 1
-	CREATE CONTINUOUS QUERY cq_autogen ON powerwall BEGIN SELECT mean(home) AS home, mean(solar) AS solar, mean(from_pw) AS from_pw, mean(to_pw) AS to_pw, mean(from_grid) AS from_grid, mean(to_grid) AS to_grid, last(percentage) AS percentage INTO powerwall.autogen.:MEASUREMENT FROM (SELECT load_instant_power AS home, solar_instant_power AS solar, abs((1+battery_instant_power/abs(battery_instant_power))*battery_instant_power/2) AS from_pw, abs((1-battery_instant_power/abs(battery_instant_power))*battery_instant_power/2) AS to_pw, abs((1+site_instant_power/abs(site_instant_power))*site_instant_power/2) AS from_grid, abs((1-site_instant_power/abs(site_instant_power))*site_instant_power/2) AS to_grid, percentage FROM raw.http) GROUP BY time(1m), month, year fill(linear) END
-	CREATE CONTINUOUS QUERY cq_kwh ON powerwall RESAMPLE EVERY 1m BEGIN SELECT integral(home)/1000/3600 AS home, integral(solar)/1000/3600 AS solar, integral(from_pw)/1000/3600 AS from_pw, integral(to_pw)/1000/3600 AS to_pw, integral(from_grid)/1000/3600 AS from_grid, integral(to_grid)/1000/3600 AS to_grid INTO powerwall.kwh.:MEASUREMENT FROM autogen.http GROUP BY time(1h), month, year tz('Australia/Adelaide') END
-	CREATE CONTINUOUS QUERY cq_daily ON powerwall RESAMPLE EVERY 1h BEGIN SELECT sum(home) AS home, sum(solar) AS solar, sum(from_pw) AS from_pw, sum(to_pw) AS to_pw, sum(from_grid) AS from_grid, sum(to_grid) AS to_grid INTO powerwall.daily.:MEASUREMENT FROM powerwall.kwh.http GROUP BY time(1d), month, year tz('Australia/Adelaide') END 
-	CREATE CONTINUOUS QUERY cq_monthly ON powerwall RESAMPLE EVERY 1h BEGIN SELECT sum(home) AS home, sum(solar) AS solar, sum(from_pw) AS from_pw, sum(to_pw) AS to_pw, sum(from_grid) AS from_grid, sum(to_grid) AS to_grid INTO powerwall.monthly.:MEASUREMENT FROM powerwall.daily.http GROUP BY time(365d), month, year END
+	CREATE CONTINUOUS QUERY cq_autogen ON powerwall BEGIN SELECT mean(home) AS home, mean(solar) AS solar, mean(from_pw) AS from_pw, mean(to_pw) AS to_pw, mean(from_grid) AS from_grid, mean(to_grid) AS to_grid, last(percentage) AS percentage INTO powerwall.autogen.:MEASUREMENT FROM (SELECT load_instant_power AS home, solar_instant_power AS solar, abs((1+battery_instant_power/abs(battery_instant_power))*battery_instant_power/2) AS from_pw, abs((1-battery_instant_power/abs(battery_instant_power))*battery_instant_power/2) AS to_pw, abs((1+site_instant_power/abs(site_instant_power))*site_instant_power/2) AS from_grid, abs((1-site_instant_power/abs(site_instant_power))*site_instant_power/2) AS to_grid, percentage FROM raw.exec) GROUP BY time(1m), month, year fill(linear) END
+	CREATE CONTINUOUS QUERY cq_kwh ON powerwall RESAMPLE EVERY 1m BEGIN SELECT integral(home)/1000/3600 AS home, integral(solar)/1000/3600 AS solar, integral(from_pw)/1000/3600 AS from_pw, integral(to_pw)/1000/3600 AS to_pw, integral(from_grid)/1000/3600 AS from_grid, integral(to_grid)/1000/3600 AS to_grid INTO powerwall.kwh.:MEASUREMENT FROM autogen.exec GROUP BY time(1h), month, year tz('Australia/Adelaide') END
+	CREATE CONTINUOUS QUERY cq_daily ON powerwall RESAMPLE EVERY 1h BEGIN SELECT sum(home) AS home, sum(solar) AS solar, sum(from_pw) AS from_pw, sum(to_pw) AS to_pw, sum(from_grid) AS from_grid, sum(to_grid) AS to_grid INTO powerwall.daily.:MEASUREMENT FROM powerwall.kwh.exec GROUP BY time(1d), month, year tz('Australia/Adelaide') END 
+	CREATE CONTINUOUS QUERY cq_monthly ON powerwall RESAMPLE EVERY 1h BEGIN SELECT sum(home) AS home, sum(solar) AS solar, sum(from_pw) AS from_pw, sum(to_pw) AS to_pw, sum(from_grid) AS from_grid, sum(to_grid) AS to_grid INTO powerwall.monthly.:MEASUREMENT FROM powerwall.daily.exec GROUP BY time(365d), month, year END
 	```
 * open up Grafana in the browser at `http://<server ip>:9000` and login with `admin/admin`
 * from `Configuration\Data Sources`, add `InfluxDB` database with:

--- a/telegraf.conf
+++ b/telegraf.conf
@@ -98,15 +98,25 @@
 	skip_database_creation = false
 	retention_policy = "raw"
 
-[[inputs.http]]
-	urls = [
-		"https://powerwall/api/meters/aggregates",
-		"https://powerwall/api/system_status/soe"
+
+[[inputs.exec]]
+	commands = [
+		"/get_aggregates.sh",
+		"/get_soe.sh"
 	]
-	method = "GET"
-	insecure_skip_verify = true
-	timeout = "4s"
+	## Timeout for each command to complete.
+	timeout = "5s"
 	data_format = "json"
+
+# [[inputs.http]]
+	# urls = [
+		# "https://powerwall/api/meters/aggregates",
+		# "https://powerwall/api/system_status/soe"
+	# ]
+	# method = "GET"
+	# insecure_skip_verify = true
+	# timeout = "4s"
+	# data_format = "json"
 
 [[processors.date]]
 	tag_key = "month"

--- a/telegraf/Dockerfile
+++ b/telegraf/Dockerfile
@@ -1,0 +1,6 @@
+FROM telegraf:1.17
+
+RUN apt-get update
+RUN apt-get install -y cron
+
+COPY entrypoint.sh get_aggregates.sh get_soe.sh /

--- a/telegraf/entrypoint.sh
+++ b/telegraf/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# this file supersedes the original entrypoint.sh for telegraf containers
+# mainly because we need to fire off a cron job that runs every 20 minutes
+
+# see: https://github.com/mihailescu2m/powerwall_monitor/issues/14#issuecomment-778478572
+
+mkdir -p /tmp/cookies
+CURL_CMD="curl -s -k -i -c /tmp/cookies/pw.txt -X POST -H 'Content-Type: application/json' -d '{\"username\":\"customer\",\"password\":\"$POWERWALL_PASSWORD\",\"force_sm_off\":false}' https://powerwall/api/login/Basic"
+CRON_CMD="*/20 * * * * $CURL_CMD"
+eval $CURL_CMD
+
+( crontab -l 2>/dev/null | grep -Fv powerwall ; printf -- "$CRON_CMD\n" ) | crontab
+
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+	    set -- telegraf "$@"
+fi
+
+exec "$@"

--- a/telegraf/get_aggregates.sh
+++ b/telegraf/get_aggregates.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -k --cookie $(cat /tmp/cookies/pw.txt | tail -n 2 | cut -d $'\t' -f 6,7 | sed -e 's/\t/=/g' | tr '\n' ';') 'https://powerwall/api/meters/aggregates'

--- a/telegraf/get_soe.sh
+++ b/telegraf/get_soe.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -k --cookie $(cat /tmp/cookies/pw.txt | tail -n 2 | cut -d $'\t' -f 6,7 | sed -e 's/\t/=/g' | tr '\n' ';') 'https://powerwall/api/system_status/soe'


### PR DESCRIPTION
With the 20.49 firmware update by Tesla, the endpoints that previously
were open are no longer without authentication. Unfortunately, the
mechanism used for authentication is not HTTP basic, rather it's cookie
based. This makes it so a process runs in the background to ensure that
you always stay logged in and then executes the queries against the
endpoints with the login cookie.

However, for some reason cURL was just ignoring the cookie file on my
machine, so I had to do some extra hacks to make it pass the cookies in
on the command line. Also, this requires cron, which means by that point
I might as well build a new docker container for this process.

I should say - this is NOT something that I'm super proud of - in particular,
I'm really annoyed with the fix for the cookies and cURL, but it works.

Now, here's the major caveat: because most of the things have switched from
`http` to `exec` this breaks previous records in the database.

As I'm writing this, I realize there might be an approach where we can implement
a very simple proxy to make it so fewer changes are necessary.