### PR TITLE
fix(api): fixes for tesla 20.49 API changes

### DIFF
--- a/powerwall.yml
+++ b/powerwall.yml
@@ -20,7 +20,7 @@ services:
               mode: host
 
     telegraf:
-        image: telegraf:1.12
+        build: telegraf
         container_name: telegraf
         hostname: telegraf
         restart: always
@@ -33,6 +33,8 @@ services:
             - "powerwall: 192.168.91.1"
         depends_on:
             - influxdb
+        env_file:
+            - .env.telegraf
 
     grafana:
         image: grafana/grafana:6.5.1-ubuntu

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,11 @@ Monitoring the Tesla Powerwall with the TICK framework
 
 ## Installation
 * edit `powerwall.yml` and replace `192.168.91.1` with your powerwall IP
+* create a file called `.env.telegraf` to define the `POWERWALL_PASSWORD` which
+  is used for authentication. This should be a single line that looks like this:
+	```
+	POWERWALL_PASSWORD=YourPowerwallPassword
+	```
 * start the docker containers: `docker-compose -f powerwall.yml up -d`
 * connect to the Influx database shell: `docker exec -it influxdb influx`
 * at the database prompt, enter the following commands:

--- a/telegraf.conf
+++ b/telegraf.conf
@@ -100,8 +100,8 @@
 
 [[inputs.http]]
 	urls = [
-		"https://powerwall/api/meters/aggregates",
-		"https://powerwall/api/system_status/soe"
+		"http://localhost:8675/p/?target=https://powerwall/api/meters/aggregates",
+		"http://localhost:8675/p/?target=https://powerwall/api/system_status/soe"
 	]
 	method = "GET"
 	insecure_skip_verify = true

--- a/telegraf/Dockerfile
+++ b/telegraf/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.16-buster as build
+RUN go get github.com/pridkett/cookieproxy
+
+FROM telegraf:1.17
+
+RUN apt-get update
+RUN apt-get install -y cron
+
+COPY --from=build /go/bin/cookieproxy .
+COPY cookieproxy.sh /etc/init.d/cookieproxy
+COPY entrypoint.sh /

--- a/telegraf/cookieproxy.sh
+++ b/telegraf/cookieproxy.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Start/stop cookieproxy
+#
+### BEGIN INIT INFO
+# Provides:          cron
+# Required-Start:    $network
+# Required-Stop:     $network
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: CookieProxy is used to proxy telegraf connections with cookies
+# Description:       Telegraf doesn't work well with connecitons that need
+#                    cookies. CookieProxy can work as a shim to proxy through to
+#                    hosts that need cookies.
+### END INIT INFO
+
+
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+DESC="cookieproxy"
+NAME=cookieproxy
+DAEMON=/cookieproxy
+PIDFILE=/var/run/cookieproxy.pid
+SCRIPTNAME=/etc/init.d/"$NAME"
+EXTRA_OPTS="-cookiejar /tmp/cookies/powerwall.txt"
+STDOUT=/dev/null
+STDERR=/dev/null
+
+test -f $DAEMON || exit 0
+
+. /lib/lsb/init-functions
+
+case "$1" in
+start)  log_daemon_msg "Starting Telegraf cookie aware proxy" "cookieproxy"
+        start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- $EXTRA_OPTS >>$STDOUT 2>>$STDERR &
+        log_end_msg $?
+        ;;
+stop)   log_daemon_msg "Stopping Telegraf cookie aware proxy" "cookieproxy"
+        killproc -p $PIDFILE $DAEMON
+        RETVAL=$?
+        [ $RETVAL -eq 0 ] && [ -e "$PIDFILE" ] && rm -f $PIDFILE
+        log_end_msg $RETVAL
+        ;;
+restart) log_daemon_msg "Restarting Telegraf cookie aware proxy" "cookieproxy"
+        $0 stop
+        $0 start
+        ;;
+reload|force-reload) log_daemon_msg "Reloading configuration files for Telegraf cookie aware proxy" "cookieproxy"
+        # there is no real way to reload cookieproxy right now
+	$0 stop
+	$0 start
+        ;;
+status)
+        status_of_proc -p $PIDFILE $DAEMON $NAME && exit 0 || exit $?
+        ;;
+*)      log_action_msg "Usage: /etc/init.d/cookieproxy {start|stop|status|restart|reload|force-reload}"
+        exit 2
+        ;;
+esac
+exit 0
+

--- a/telegraf/entrypoint.sh
+++ b/telegraf/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# this file supersedes the original entrypoint.sh for telegraf containers
+# mainly because we need to fire off a cron job that runs every 20 minutes
+
+# see: https://github.com/mihailescu2m/powerwall_monitor/issues/14#issuecomment-778478572
+
+mkdir -p /tmp/cookies
+CURL_CMD="curl -s -k -o /dev/null -c /tmp/cookies/powerwall.txt -X POST -H 'Content-Type: application/json' -d '{\"username\":\"customer\",\"password\":\"$POWERWALL_PASSWORD\",\"force_sm_off\":false}' https://powerwall/api/login/Basic"
+CRON_CMD="*/20 * * * * $CURL_CMD"
+eval $CURL_CMD
+
+( crontab -l 2>/dev/null | grep -Fv powerwall ; printf -- "$CRON_CMD\n" ) | crontab
+
+/etc/init.d/cookieproxy start
+
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+	    set -- telegraf "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
**NOTE: This supersedes PR #15.** The major difference between the two PRs is that using this PR will allow people to maintain their existing data streams. It creates a custom Telegraf container with a proxy running inside of it that passes the cookies through to the Powerwall. To the best of my ability, I believe this is the only way to get Telegraf to pass cookies on a request.

With the 20.49 firmware update by Tesla, the endpoints that previously
were open are no longer without authentication. Unfortuantely, the
mechanism used for authentication is not HTTP basic, rather it's cookie
based. This brings in a very simple cookie aware proxy to run in the
telegraf container. In short, cron updates the cookies every two minutes
and then cookieproxy forwards to connection with cookies through to the
Powerwall.

Fixes mihailescu2m/powerwall_monitor#14

DCO 1.1 Signed-off-by: Patrick Wagstrom <patrick@wagstrom.net>