### PR TITLE
fix(api): fixes for tesla 20.49 API changes

### DIFF
--- a/powerwall.yml
+++ b/powerwall.yml
@@ -19,6 +19,17 @@ services:
               published: 8086
               mode: host
 
+    cookieproxy:
+        image: pridkett/cookieproxy:0.1.0
+        container_name: cookieproxy
+        hostname: cookieproxy
+        restart: always
+        command: ["/bin/sh", "-c", '/go/bin/cookieproxy -request "{\"url\": \"https://powerwall/api/login/Basic\", \"headers\": {\"Content-Type\": \"application/json\"}, \"body\": \"{\\\"username\\\":\\\"customer\\\",\\\"password\\\":\\\"$$POWERWALL_PASSWORD\\\", \\\"force_sm_off\\\":false}\", \"method\": \"POST\"}"']
+        extra_hosts:
+            - "powerwall: 192.168.91.1"
+        env_file:
+            - .env.cookieproxy
+
     telegraf:
         image: telegraf:1.12
         container_name: telegraf
@@ -29,10 +40,9 @@ services:
               source: ./telegraf.conf
               target: /etc/telegraf/telegraf.conf
               read_only: true
-        extra_hosts:
-            - "powerwall: 192.168.91.1"
         depends_on:
             - influxdb
+            - cookieproxy
 
     grafana:
         image: grafana/grafana:6.5.1-ubuntu

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,11 @@ Monitoring the Tesla Powerwall with the TICK framework
 
 ## Installation
 * edit `powerwall.yml` and replace `192.168.91.1` with your powerwall IP
+* create a file called `.env.cookieproxy` to define the `POWERWALL_PASSWORD` which
+  is used for authentication. This should be a single line that looks like this:
+	```
+	POWERWALL_PASSWORD=YourPowerwallPassword
+	```
 * start the docker containers: `docker-compose -f powerwall.yml up -d`
 * connect to the Influx database shell: `docker exec -it influxdb influx`
 * at the database prompt, enter the following commands:

--- a/telegraf.conf
+++ b/telegraf.conf
@@ -100,8 +100,8 @@
 
 [[inputs.http]]
 	urls = [
-		"https://powerwall/api/meters/aggregates",
-		"https://powerwall/api/system_status/soe"
+		"http://cookieproxy:8675/p/?target=https://powerwall/api/meters/aggregates",
+		"http://cookieproxy:8675/p/?target=https://powerwall/api/system_status/soe"
 	]
 	method = "GET"
 	insecure_skip_verify = true


### PR DESCRIPTION
With the 20.49 firmware update by Tesla, the endpoints that previously
were open are no longer available without authentication. Unfortuantely,
the mechanism used for authentication is not HTTP basic, rather it's
cookie based. This change brings in an additional container that I
created called cookieproxy, that can be used to proxy the cookie based
requests through to the Powerwall gateway.

In contrast to previous versions, this requires no compilation of
containers on the local machine and no modifications to the more common
containers of influxdb, grafana, and telegraf. There is a small
customization that is required to store the password of your Powerwall
in the `.env.cookieproxy` file, but otherwise it should be plug and play
with the previous versions of mihailescu2m/powerwall_monitor.

Root issue: mihailescu2m/powerwall_monitor#14

This supersedes my previous attempts at a patch including mihailescu2m/powerwall_monitor#16