### PR TITLE
Update y-axis label from kW to kWh for 4 monthly graphs

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -1899,7 +1899,7 @@
       },
       "yaxes": [
         {
-          "format": "kwatt",
+          "format": "kwatth",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -2028,7 +2028,7 @@
       },
       "yaxes": [
         {
-          "format": "kwatt",
+          "format": "kwatth",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -2151,7 +2151,7 @@
       },
       "yaxes": [
         {
-          "format": "kwatt",
+          "format": "kwatth",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -2329,7 +2329,7 @@
       },
       "yaxes": [
         {
-          "format": "kwatt",
+          "format": "kwatth",
           "label": null,
           "logBase": 1,
           "max": null,


### PR DESCRIPTION
The 4 monthly graphs show kW instead of kWh on the y-axis.  This PR is to fix that.